### PR TITLE
go/graph: use interface{}, not *interface{} for value

### DIFF
--- a/go/graph/graph.go
+++ b/go/graph/graph.go
@@ -44,7 +44,7 @@ type Node struct {
 	// can test for equality on Nodes. The pointer wont change,
 	// the value it points to will. If the pointer is explicitly changed,
 	// graph functions that use Nodes will cease to work.
-	Value *interface{}
+	Value interface{}
 }
 
 type edge struct {


### PR DESCRIPTION
In Go, you should use interface{}. An interface{} contains two things:

 - Type identifier
 - Pointer to actual value

You cannot actually assign to a *interface{} field, you will always get the error "*interface{} is pointer to interface, not interface."

It also doesn't make sense to take a pointer to a interface{}, as the interface{} contains a pointer anyway.

You can compare two interface{} with == equality comparison and it will compare both their type and the actual pointer, so the intended behavior holds.