### PR TITLE
go/graph: Set parent to nil during Dijkstra init.

### DIFF
--- a/go/graph/search.go
+++ b/go/graph/search.go
@@ -19,6 +19,7 @@ func (g *Graph) DijkstraSearch(start Node) []Path {
 	for i := range nodesBase {
 		nodesBase[i].state = 1<<31 - 1
 		nodesBase[i].data = i
+		nodesBase[i].parent = nil
 	}
 	start.node.state = 0 // make it so 'start' sorts to the top of the heap
 	nodes := &nodesBase


### PR DESCRIPTION
Failing to do so causes weird behavior on the second run of Dijkstra's
search. This is a result of parent's use during the first run.